### PR TITLE
Rename System.Text.Json.Serialization.JsonPropertyName for SlackApiMessage.PostAt from "username" to "post_at"

### DIFF
--- a/SlackMessageBuilder/Objects/SlackApiMessage.cs
+++ b/SlackMessageBuilder/Objects/SlackApiMessage.cs
@@ -176,7 +176,7 @@ namespace Slack.MessageBuilder.Objects
 #if NEWTONSOFTJSON || DEBUG
         [Newtonsoft.Json.JsonProperty("post_at")]
 #elif SYSTEMTEXTJSON|| DEBUG
-        [System.Text.Json.Serialization.JsonPropertyName("username")]
+        [System.Text.Json.Serialization.JsonPropertyName("post_at")]
 #endif
         public int? PostAt { get; }
     }


### PR DESCRIPTION
Resolves the following error

    System.InvalidOperationException: The JSON property name for 'Slack.MessageBuilder.Objects.SlackApiMessage.username' collides with another property.